### PR TITLE
BUG: fix bug split path file

### DIFF
--- a/azurebatchload/download.py
+++ b/azurebatchload/download.py
@@ -1,6 +1,8 @@
-import os
 import logging
+import os
+
 from azure.storage.blob import BlobServiceClient
+
 from azurebatchload.core import Base
 
 
@@ -59,7 +61,7 @@ class Download(Base):
                 if self.extensions and not blob.name.lower().endswith(self.extensions.lower()):
                     continue
 
-                file_path, file_name = blob.name.rsplit("/", 1)
+                file_path, file_name = os.path.split(blob.name)
 
                 if self.list_files and file_name not in self.list_files:
                     continue

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = azurebatchload
-version = 0.5.2
+version = 0.5.3
 author = Erfan Nariman, Melvin Folkers
 author_email = hello@zypp.io
 description = Download files in batches from Azure Blob Storage Containers


### PR DESCRIPTION
Use `os.path.split` to split path from file